### PR TITLE
Update Searching Wilayah Indonesia Based on URL Given

### DIFF
--- a/src/Http/Controllers/WilayahIndonesiaController.php
+++ b/src/Http/Controllers/WilayahIndonesiaController.php
@@ -63,6 +63,63 @@ class WilayahIndonesiaController extends Controller
 		$page 					= 10;
 		if($provinsi == 'provinsi'){
 			$data 					= $this->indonesia->paginateProvinces($page);			
+		}elseif($provinsi == 'kabupaten'){
+			$data 					= $this->provinsi
+									->select(
+										'provinces.id as province_id',
+										'provinces.name as province_name',
+										'cities.id as city_id',
+										'cities.name as city_name'
+									)
+									->leftjoin(
+										'cities',
+										'provinces.id','=','cities.province_id'
+									)
+									->paginate($page);
+		}elseif($provinsi == 'kecamatan'){
+			$data 					= $this->provinsi
+									->select(
+										'provinces.id as province_id',
+										'provinces.name as province_name',
+										'cities.id as city_id',
+										'cities.name as city_name',
+										'districts.id as district_id',
+										'districts.name as district_name'
+									)
+									->leftjoin(
+										'cities',
+										'provinces.id','=','cities.province_id'
+									)
+									->leftjoin(
+										'districts',
+										'cities.id','=','districts.city_id'
+									)
+									->paginate($page);
+		}elseif($provinsi == 'desa'){
+		$data 					= $this->provinsi
+								->select(
+									'provinces.id as province_id',
+									'provinces.name as province_name',
+									'cities.id as city_id',
+									'cities.name as city_name',
+									'districts.id as district_id',
+									'districts.name as district_name',
+									'villages.id as village_id',
+									'villages.name as village_name'
+								)
+								->leftjoin(
+									'cities',
+									'provinces.id','=','cities.province_id'
+								)
+								->leftjoin(
+									'districts',
+									'cities.id','=','districts.city_id'
+								)
+								->leftjoin(
+									'villages',
+									'districts.id','=','villages.district_id'
+								)
+								->paginate($page);
 		}else{
 			$string 				= array('%20','+','-');
 			foreach($string as $val){
@@ -96,7 +153,7 @@ class WilayahIndonesiaController extends Controller
 	public function kabupatenindex()
 	{	
 		$page  					= 10;
-		$res 					= $this->provinsi
+		$data 					= $this->provinsi
 								->select(
 									'provinces.id as province_id',
 									'provinces.name as province_name',
@@ -108,7 +165,7 @@ class WilayahIndonesiaController extends Controller
 									'provinces.id','=','cities.province_id'
 								)
 								->paginate($page);
-		return Response::make(json_encode($res, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");
+		return Response::make(json_encode($data, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");
 	}
 	public function kabupatencreate()
 	{
@@ -131,6 +188,63 @@ class WilayahIndonesiaController extends Controller
 		$page 					= 10;
 		if($provinsi == 'provinsi'){
 			$data 					= $this->indonesia->paginateProvinces($page);			
+		}elseif($provinsi == 'kabupaten'){
+			$data 					= $this->provinsi
+									->select(
+										'provinces.id as province_id',
+										'provinces.name as province_name',
+										'cities.id as city_id',
+										'cities.name as city_name'
+									)
+									->leftjoin(
+										'cities',
+										'provinces.id','=','cities.province_id'
+									)
+									->paginate($page);
+		}elseif($provinsi == 'kecamatan'){
+			$data 					= $this->provinsi
+									->select(
+										'provinces.id as province_id',
+										'provinces.name as province_name',
+										'cities.id as city_id',
+										'cities.name as city_name',
+										'districts.id as district_id',
+										'districts.name as district_name'
+									)
+									->leftjoin(
+										'cities',
+										'provinces.id','=','cities.province_id'
+									)
+									->leftjoin(
+										'districts',
+										'cities.id','=','districts.city_id'
+									)
+									->paginate($page);
+		}elseif($provinsi == 'desa'){
+		$data 					= $this->provinsi
+								->select(
+									'provinces.id as province_id',
+									'provinces.name as province_name',
+									'cities.id as city_id',
+									'cities.name as city_name',
+									'districts.id as district_id',
+									'districts.name as district_name',
+									'villages.id as village_id',
+									'villages.name as village_name'
+								)
+								->leftjoin(
+									'cities',
+									'provinces.id','=','cities.province_id'
+								)
+								->leftjoin(
+									'districts',
+									'cities.id','=','districts.city_id'
+								)
+								->leftjoin(
+									'villages',
+									'districts.id','=','villages.district_id'
+								)
+								->paginate($page);
 		}else{
 			$string 				= array('%20','+','-');
 			foreach($string as $val){
@@ -211,7 +325,7 @@ class WilayahIndonesiaController extends Controller
 	public function kecamatanindex()
 	{
 		$page  					= 10;
-		$res 					= $this->provinsi
+		$data 					= $this->provinsi
 								->select(
 									'provinces.id as province_id',
 									'provinces.name as province_name',
@@ -229,7 +343,7 @@ class WilayahIndonesiaController extends Controller
 									'cities.id','=','districts.city_id'
 								)
 								->paginate($page);
-		return Response::make(json_encode($res, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");		
+		return Response::make(json_encode($data, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");		
 	}
 	public function kecamatancreate()
 	{
@@ -252,6 +366,63 @@ class WilayahIndonesiaController extends Controller
 		$page 					= 10;
 		if($provinsi == 'provinsi'){
 			$data 					= $this->indonesia->paginateProvinces($page);			
+		}elseif($provinsi == 'kabupaten'){
+			$data 					= $this->provinsi
+									->select(
+										'provinces.id as province_id',
+										'provinces.name as province_name',
+										'cities.id as city_id',
+										'cities.name as city_name'
+									)
+									->leftjoin(
+										'cities',
+										'provinces.id','=','cities.province_id'
+									)
+									->paginate($page);
+		}elseif($provinsi == 'kecamatan'){
+			$data 					= $this->provinsi
+									->select(
+										'provinces.id as province_id',
+										'provinces.name as province_name',
+										'cities.id as city_id',
+										'cities.name as city_name',
+										'districts.id as district_id',
+										'districts.name as district_name'
+									)
+									->leftjoin(
+										'cities',
+										'provinces.id','=','cities.province_id'
+									)
+									->leftjoin(
+										'districts',
+										'cities.id','=','districts.city_id'
+									)
+									->paginate($page);
+		}elseif($provinsi == 'desa'){
+		$data 					= $this->provinsi
+								->select(
+									'provinces.id as province_id',
+									'provinces.name as province_name',
+									'cities.id as city_id',
+									'cities.name as city_name',
+									'districts.id as district_id',
+									'districts.name as district_name',
+									'villages.id as village_id',
+									'villages.name as village_name'
+								)
+								->leftjoin(
+									'cities',
+									'provinces.id','=','cities.province_id'
+								)
+								->leftjoin(
+									'districts',
+									'cities.id','=','districts.city_id'
+								)
+								->leftjoin(
+									'villages',
+									'districts.id','=','villages.district_id'
+								)
+								->paginate($page);
 		}else{
 			$string 				= array('%20','+','-');
 			foreach($string as $val){
@@ -385,7 +556,7 @@ class WilayahIndonesiaController extends Controller
 	public function desaindex()
 	{
 		$page  					= 10;
-		$res 					= $this->provinsi
+		$data 					= $this->provinsi
 								->select(
 									'provinces.id as province_id',
 									'provinces.name as province_name',
@@ -409,7 +580,7 @@ class WilayahIndonesiaController extends Controller
 									'districts.id','=','villages.district_id'
 								)
 								->paginate($page);
-		return Response::make(json_encode($res, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");		
+		return Response::make(json_encode($data, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");		
 	}
 	public function desacreate()
 	{

--- a/src/Http/Controllers/WilayahIndonesiaController.php
+++ b/src/Http/Controllers/WilayahIndonesiaController.php
@@ -4,6 +4,9 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Bantenprov\WilayahIndonesia\Facades\WilayahIndonesia;
 use Bantenprov\WilayahIndonesia\Models\Provinsi;
+use Bantenprov\WilayahIndonesia\Models\Kabupaten;
+use Bantenprov\WilayahIndonesia\Models\Kecamatan;
+use Bantenprov\WilayahIndonesia\Models\Desa;
 use Laravolt\Indonesia\Indonesia;
 use Illuminate\Support\Facades\Input;
 use Response;
@@ -25,6 +28,9 @@ class WilayahIndonesiaController extends Controller
 	{
 		$this->indonesia 	= new Indonesia;
 		$this->provinsi 	= new Provinsi;
+		$this->kabupaten 	= new Kabupaten;
+		$this->kecamatan 	= new Kecamatan;
+		$this->desa 		= new Desa;
 	}
 	public function provinsiindex()
 	{
@@ -51,6 +57,38 @@ class WilayahIndonesiaController extends Controller
 	public function provinsipage()
 	{
 		
+	}
+	public function provinsisearch($provinsi)
+	{		
+		$page 					= 10;
+		if($provinsi == 'provinsi'){
+			$data 					= $this->indonesia->paginateProvinces($page);			
+		}else{
+			$string 				= array('%20','+','-');
+			foreach($string as $val){
+				$provinsi 			= str_replace($val,' ',$provinsi);
+			}
+			$prov 						= $this->provinsi->where("name","=","$provinsi")->get();
+			if($prov->count() > 0){
+				$provinsi 				= $prov[0]->id;
+				$data 					= $this->provinsi
+										->select(
+											'provinces.id as province_id',
+											'provinces.name as province_name',
+											'cities.id as city_id',
+											'cities.name as city_name'
+										)
+										->leftjoin(
+											'cities',
+											'provinces.id','=','cities.province_id'
+										)
+										->where('cities.province_id','=',$provinsi)
+										->paginate($page);
+			}else{
+				$data 					= $this->indonesia->paginateProvinces($page);							
+			}
+		}
+		return Response::make(json_encode($data, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");
 	}
 	//END DATA PROVINSI
 
@@ -88,8 +126,87 @@ class WilayahIndonesiaController extends Controller
 	{
 		
 	}
+	public function kabupatensearch($provinsi,$kabupaten)
+	{		
+		$page 					= 10;
+		if($provinsi == 'provinsi'){
+			$data 					= $this->indonesia->paginateProvinces($page);			
+		}else{
+			$string 				= array('%20','+','-');
+			foreach($string as $val){
+				$provinsi 			= str_replace($val,' ',$provinsi);
+			}
+			$prov 					= $this->provinsi->where("name","=","$provinsi")->get();
+			if($prov->count() > 0){
+				$provinsi 				= $prov[0]->id;
+				foreach($string as $val){
+					$kabupaten 				= str_replace($val,' ',$kabupaten);
+				}
+				$kab 						= $this->kabupaten->where("province_id","=","$provinsi")->where("name","=","$kabupaten")->get();
+				if($kab->count() == 0){
+					$kabupaten 				= 'kabupaten '.$kabupaten;
+				}
+				$kab1 						= $this->kabupaten->where("province_id","=","$provinsi")->where("name","=","$kabupaten")->get();
+				if($kab1->count() == 0){
+					$kabupaten 				= 'kab '.$kabupaten;
+				}
+				$kab2 						= $this->kabupaten->where("province_id","=","$provinsi")->where("name","=","$kabupaten")->get();
+				if($kab2->count() == 0){
+					$kabupaten 				= 'kab. '.$kabupaten;
+				}
+				$kab3 						= $this->kabupaten->where("province_id","=","$provinsi")->where("name","=","$kabupaten")->get();
+				if(($kab->count() > 0) || ($kab1->count() > 0) || ($kab2->count() > 0) || ($kab3->count() > 0)){
+					if(isset($kab[0]->id)){
+						$kabupaten 			= $kab[0]->id;
+					}elseif(isset($kab1[0]->id)){
+						$kabupaten 			= $kab1[0]->id;						
+					}elseif(isset($kab2[0]->id)){
+						$kabupaten 			= $kab2[0]->id;						
+					}elseif(isset($kab3[0]->id)){
+						$kabupaten 			= $kab3[0]->id;						
+					}
+					$data 					= $this->provinsi
+											->select(
+												'provinces.id as province_id',
+												'provinces.name as province_name',
+												'cities.id as city_id',
+												'cities.name as city_name',
+												'districts.id as district_id',
+												'districts.name as district_name'
+											)
+											->leftjoin(
+												'cities',
+												'provinces.id','=','cities.province_id'
+											)
+											->leftjoin(
+												'districts',
+												'cities.id','=','districts.city_id'
+											)
+											->where('districts.city_id','=',$kabupaten)
+											->paginate($page);
+				}else{
+					$data 					= $this->provinsi
+											->select(
+												'provinces.id as province_id',
+												'provinces.name as province_name',
+												'cities.id as city_id',
+												'cities.name as city_name'
+											)
+											->leftjoin(
+												'cities',
+												'provinces.id','=','cities.province_id'
+											)
+											->where('cities.province_id','=',$provinsi)
+											->paginate($page);
+				}
+			}else{
+				$data 					= $this->indonesia->paginateProvinces($page);							
+			}
+		}
+		return Response::make(json_encode($data, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");
+	}
 	//END DATA KABUPATEN
-
+	
 	//DATA KECAMATAN
 	public function kecamatanindex()
 	{
@@ -129,6 +246,138 @@ class WilayahIndonesiaController extends Controller
 	public function kecamatandelete()
 	{
 		
+	}
+	public function kecamatansearch($provinsi,$kabupaten,$kecamatan)
+	{		
+		$page 					= 10;
+		if($provinsi == 'provinsi'){
+			$data 					= $this->indonesia->paginateProvinces($page);			
+		}else{
+			$string 				= array('%20','+','-');
+			foreach($string as $val){
+				$provinsi 			= str_replace($val,' ',$provinsi);
+			}
+			$prov 					= $this->provinsi->where("name","=","$provinsi")->get();
+			if($prov->count() > 0){
+				$provinsi 				= $prov[0]->id;
+				foreach($string as $val){
+					$kabupaten 				= str_replace($val,' ',$kabupaten);
+				}
+				$kab 						= $this->kabupaten->where("province_id","=","$provinsi")->where("name","=","$kabupaten")->get();
+				if($kab->count() == 0){
+					$kabupaten 				= 'kabupaten '.$kabupaten;
+				}
+				$kab1 						= $this->kabupaten->where("province_id","=","$provinsi")->where("name","=","$kabupaten")->get();
+				if($kab1->count() == 0){
+					$kabupaten 				= 'kab '.$kabupaten;
+				}
+				$kab2 						= $this->kabupaten->where("province_id","=","$provinsi")->where("name","=","$kabupaten")->get();
+				if($kab2->count() == 0){
+					$kabupaten 				= 'kab. '.$kabupaten;
+				}
+				$kab3 						= $this->kabupaten->where("province_id","=","$provinsi")->where("name","=","$kabupaten")->get();
+				if(($kab->count() > 0) || ($kab1->count() > 0) || ($kab2->count() > 0) || ($kab3->count() > 0)){
+					if(isset($kab[0]->id)){
+						$kabupaten 			= $kab[0]->id;
+					}elseif(isset($kab1[0]->id)){
+						$kabupaten 			= $kab1[0]->id;						
+					}elseif(isset($kab2[0]->id)){
+						$kabupaten 			= $kab2[0]->id;						
+					}elseif(isset($kab3[0]->id)){
+						$kabupaten 			= $kab3[0]->id;						
+					}
+					foreach($string as $val){
+						$kecamatan 				= str_replace($val,' ',$kecamatan);
+					}
+					$kec 						= $this->kecamatan->where("city_id","=","$kabupaten")->where("name","=","$kecamatan")->get();
+					if($kec->count() == 0){
+						$kecamatan 				= 'kecamatan '.$kecamatan;
+					}
+					$kec1 						= $this->kecamatan->where("city_id","=","$kabupaten")->where("name","=","$kecamatan")->get();
+					if($kec1->count() == 0){
+						$kecamatan 				= 'kec '.$kecamatan;
+					}
+					$kec2 						= $this->kecamatan->where("city_id","=","$kabupaten")->where("name","=","$kecamatan")->get();
+					if($kec2->count() == 0){
+						$kecamatan 				= 'kec. '.$kecamatan;
+					}
+					$kec3 						= $this->kecamatan->where("city_id","=","$kabupaten")->where("name","=","$kecamatan")->get();
+					if(($kec->count() > 0) || ($kec1->count() > 0) || ($kec2->count() > 0) || ($kec3->count() > 0)){
+						if(isset($kec[0]->id)){
+							$kecamatan 			= $kec[0]->id;
+						}elseif(isset($kec1[0]->id)){
+							$kecamatan 			= $kec1[0]->id;						
+						}elseif(isset($kec2[0]->id)){
+							$kecamatan 			= $kec2[0]->id;						
+						}elseif(isset($kec3[0]->id)){
+							$kecamatan 			= $kec3[0]->id;						
+						}
+						$data 					= $this->provinsi
+												->select(
+													'provinces.id as province_id',
+													'provinces.name as province_name',
+													'cities.id as city_id',
+													'cities.name as city_name',
+													'districts.id as district_id',
+													'districts.name as district_name',
+													'villages.id as village_id',
+													'villages.name as village_name'
+												)
+												->leftjoin(
+													'cities',
+													'provinces.id','=','cities.province_id'
+												)
+												->leftjoin(
+													'districts',
+													'cities.id','=','districts.city_id'
+												)
+												->leftjoin(
+													'villages',
+													'districts.id','=','villages.district_id'
+												)
+												->where('villages.district_id','=',$kecamatan)
+												->paginate($page);
+					}else{
+						$data 					= $this->provinsi
+												->select(
+													'provinces.id as province_id',
+													'provinces.name as province_name',
+													'cities.id as city_id',
+													'cities.name as city_name',
+													'districts.id as district_id',
+													'districts.name as district_name'
+												)
+												->leftjoin(
+													'cities',
+													'provinces.id','=','cities.province_id'
+												)
+												->leftjoin(
+													'districts',
+													'cities.id','=','districts.city_id'
+												)
+												->where('districts.city_id','=',$kabupaten)
+												->paginate($page);						
+					}
+				}else{
+					$data 					= $this->provinsi
+											->select(
+												'provinces.id as province_id',
+												'provinces.name as province_name',
+												'cities.id as city_id',
+												'cities.name as city_name'
+											)
+											->leftjoin(
+												'cities',
+												'provinces.id','=','cities.province_id'
+											)
+											->where('cities.province_id','=',$provinsi)
+											->paginate($page);
+				}
+			}else{
+				$data 					= $this->indonesia->paginateProvinces($page);							
+			}
+		}
+		return Response::make(json_encode($data, JSON_PRETTY_PRINT))->header('Content-Type', "application/json");
 	}
 	//END DATA KECAMATAN
 

--- a/src/routes/routes.php
+++ b/src/routes/routes.php
@@ -9,6 +9,7 @@ Route::group(['prefix' => 'wilayah-indonesia'], function() {
     Route::get('/provinsi/{id}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@provinsishow');
     Route::post('/provinsi/{id}/edit', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@provinsiedit');
     Route::post('/provinsi/{id}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@provinsidelete');
+    Route::get('/{provinsi}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@provinsisearch');
 	//END ROUTE PROVINSI
 
 	//ROUTE KABUPATEN
@@ -17,17 +18,21 @@ Route::group(['prefix' => 'wilayah-indonesia'], function() {
     Route::get('/kabupaten/{id}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kabupatenshow');
     Route::post('/kabupaten/{id}/edit', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kabupatenedit');
     Route::post('/kabupaten/{id}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kabupatendelete');
+    Route::get('/{provinsi}/{kabupaten}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kabupatensearch');
 	//END ROUTE KABUPATEN
 
 	//ROUTE KECAMATAN
+    Route::get('/{kecamatan}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kecamatansearch');
     Route::get('/kecamatan', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kecamatanindex');
     Route::post('/kecamatan/create', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kecamatancreate');
     Route::get('/kecamatan/{id}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kecamatanshow');
     Route::post('/kecamatan/{id}/edit', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kecamatanedit');
     Route::post('/kecamatan/{id}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kecamatandelete');
+    Route::get('/{provinsi}/{kabupaten}/{kecamatan}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@kecamatansearch');
 	//END ROUTE KECAMATAN
 	
 	//ROUTE DESA
+    Route::get('/{desa}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@desasearch');
     Route::get('/desa', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@desaindex');
     Route::post('/desa/create', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@desacreate');
     Route::get('/desa/{id}', 'Bantenprov\WilayahIndonesia\Http\Controllers\WilayahIndonesiaController@desashow');


### PR DESCRIPTION
Update Searching Wilayah Indonesia Based on URL Given.
- Returning json data of provinces when giving url wilaya-indonesia
- Returning json data of kabupatens/cities when type province on province slug, example: wilaya-indonesia/jakarta
- Returning all json kabupatens/cities data when giving mistype of word on province slug, example wilaya-indonesia/jakarta/djakarta-utara [the right one is wilayah-indonesia/jakarta/jakarta-utara]
- Returning json data of kecamatans/districts when type kabupaten/city on kabupaten/city slug, example: wilaya-indonesia/jakarta/jakarta-utara
and soon.


